### PR TITLE
InPlayer Plugin - add support for the "requires_authentication" field

### DIFF
--- a/plugins/login-plugin/src/Utils/PayloadUtils/index.js
+++ b/plugins/login-plugin/src/Utils/PayloadUtils/index.js
@@ -1,6 +1,16 @@
 import R from "ramda";
 
+export const isAuthenticationRequired = ({ payload }) => {
+  const requires_authentication = R.path([
+    "extensions",
+    "requires_authentication",
+  ])(payload);
+  console.log({ requires_authentication });
+  return requires_authentication;
+};
+
 export const inPlayerAssetId = ({ payload, configuration }) => {
+  console.log({ payload, configuration });
   const assetIdFromCustomKey = inPlayerAssetIdFromCustomKey({
     payload,
     configuration,

--- a/plugins/login-plugin/src/Utils/PayloadUtils/index.js
+++ b/plugins/login-plugin/src/Utils/PayloadUtils/index.js
@@ -5,12 +5,10 @@ export const isAuthenticationRequired = ({ payload }) => {
     "extensions",
     "requires_authentication",
   ])(payload);
-  console.log({ requires_authentication });
   return requires_authentication;
 };
 
 export const inPlayerAssetId = ({ payload, configuration }) => {
-  console.log({ payload, configuration });
   const assetIdFromCustomKey = inPlayerAssetIdFromCustomKey({
     payload,
     configuration,


### PR DESCRIPTION
Ticket [TPS-460](https://applicaster.atlassian.net/browse/TPS-460)

Add support of extension key from dsp `requires_authentication` to define that ds must use login flow.

```
  "type": {
    "value": "video"
  },
  "id": "5718802496001",
  "title": "Video that requires login and purchase",
  "published": "2018-01-24T20:48:01+00:00",
  "extensions": {
        “requires_authentication”: true,
        “ds_product_ids”: [“entitlement1”,“entitlement2”,"entitlement3”]
    }
}
```