### PR TITLE
WIP: Android IAP library projects updated

### DIFF
--- a/plugins/login-plugin/manifests/manifest.config.js
+++ b/plugins/login-plugin/manifests/manifest.config.js
@@ -2153,12 +2153,13 @@ const project_dependencies = {
   apple: [],
   android: [
     {
-      ApplicasterIAP:
-        "./quick_brick/node_modules/@applicaster/applicaster-iap/Android/iap",
+      "iap": "./quick_brick/node_modules/@applicaster/applicaster-iap/Android/iap"
     },
     {
-      ApplicasterIAPRN:
-        "./quick_brick/node_modules/@applicaster/applicaster-iap/Android/iap-rn",
+      "iap-uni": "./quick_brick/node_modules/@applicaster/applicaster-iap/Android/iap-uni"
+    },
+    {
+      "iap-rn": "./quick_brick/node_modules/@applicaster/applicaster-iap/Android/iap-rn"
     },
     {
       "react-native-community_blur":

--- a/plugins/login-plugin/package.json
+++ b/plugins/login-plugin/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@applicaster/applicaster-iap": "0.2.15",
+    "@applicaster/applicaster-iap": "0.3.0-alpha2",
     "@applicaster/quick-brick-parent-lock": "*",
     "@inplayer-org/inplayer.js": "2.13.3",
     "@react-native-community/blur": "3.4.1",


### PR DESCRIPTION
There is new project added, iap-uni, which incapsulates access to Amazon and Google billing backends.
Other projects were renamed.
Uses alpha @applicaster/applicaster-iap (https://github.com/applicaster/applicaster-iap-framework/pull/18)