### PR TITLE
fix: removing shebang and adding lg as web to solve parsing errs

### DIFF
--- a/plugins/login-plugin/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/amazon_fire_tv_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "3.0.17",
-  "manifest_version": "3.0.17",
+  "dependency_version": "3.0.18",
+  "manifest_version": "3.0.18",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/android_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/android_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "3.0.17",
-  "manifest_version": "3.0.17",
+  "dependency_version": "3.0.18",
+  "manifest_version": "3.0.18",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/android_tv_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/android_tv_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "3.0.17",
-  "manifest_version": "3.0.17",
+  "dependency_version": "3.0.18",
+  "manifest_version": "3.0.18",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/ios_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/ios_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "3.0.17",
-  "manifest_version": "3.0.17",
+  "dependency_version": "3.0.18",
+  "manifest_version": "3.0.18",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/login-plugin/manifests/lg_tv.json
+++ b/plugins/login-plugin/manifests/lg_tv.json
@@ -1,0 +1,788 @@
+{
+  "dependency_repository_url": [],
+  "dependency_name": "@applicaster/quick-brick-inplayer",
+  "author_name": "Applicaster",
+  "author_email": "zapp@applicaster.com",
+  "name": "inPlayer Login & Payments",
+  "description": "inPlayer Login & Payments",
+  "type": "login",
+  "screen": true,
+  "react_native": true,
+  "identifier": "quick-brick-inplayer",
+  "ui_builder_support": true,
+  "whitelisted_account_ids": [
+    "5c9ce7917b225c000f02dfbc"
+  ],
+  "deprecated_since_zapp_sdk": "",
+  "unsupported_since_zapp_sdk": "",
+  "preload": true,
+  "custom_configuration_fields": [
+    {
+      "type": "text",
+      "key": "in_player_client_id",
+      "tooltip_text": "In Player Client ID",
+      "default": ""
+    },
+    {
+      "type": "number_input",
+      "key": "in_player_branding_id",
+      "tooltip_text": "In Player Branding ID"
+    },
+    {
+      "type": "text",
+      "key": "in_player_referrer",
+      "tooltip_text": "In Player Referrer URL",
+      "default": ""
+    },
+    {
+      "type": "text",
+      "key": "in_player_custom_asset_key",
+      "tooltip_text": "Custom asset key",
+      "default": "extensions.event_inplayer_id"
+    },
+    {
+      "type": "tag_select",
+      "key": "in_player_environment",
+      "tooltip_text": "InPlayer working environment",
+      "options": [
+        {
+          "text": "Development",
+          "value": "develop"
+        },
+        {
+          "text": "Production",
+          "value": "prod"
+        }
+      ],
+      "initial_value": "prod"
+    },
+    {
+      "type": "tag_select",
+      "key": "logout_completion_action",
+      "tooltip_text": "Defines what action plugin should do after user log out. ",
+      "options": [
+        {
+          "text": "Go back to previous screen",
+          "value": "go_back"
+        },
+        {
+          "text": "Go back to home screen",
+          "value": "go_home"
+        }
+      ],
+      "initial_value": "go_back"
+    },
+    {
+      "type": "text",
+      "key": "consumable_type_mapper",
+      "tooltip_text": "Mapping key for consumable purchase",
+      "default": "consumable"
+    },
+    {
+      "type": "text",
+      "key": "non_consumable_type_mapper",
+      "tooltip_text": "Mapping key for non consumable purchase",
+      "default": "ppv"
+    },
+    {
+      "type": "text",
+      "key": "subscription_type_mapper",
+      "tooltip_text": "Mapping key for subscription purchase",
+      "default": "subscription"
+    }
+  ],
+  "hooks": {
+    "fields": [
+      {
+        "group": true,
+        "label": "Before Load",
+        "folded": true,
+        "fields": [
+          {
+            "key": "preload_plugins",
+            "type": "preload_plugins_selector",
+            "label": "Select Plugins"
+          }
+        ]
+      }
+    ]
+  },
+  "ui_frameworks": [
+    "quickbrick"
+  ],
+  "platform": "lg_tv",
+  "dependency_version": "3.0.18",
+  "manifest_version": "3.0.18",
+  "api": {},
+  "project_dependencies": [],
+  "extra_dependencies": [],
+  "npm_dependencies": [
+    "@applicaster/applicaster-iap@0.3.3",
+    "@react-native-community/blur@3.4.1"
+  ],
+  "styles": {
+    "fields": [
+      {
+        "key": "background_color",
+        "type": "color_picker",
+        "label": "Background font color",
+        "initial_value": "#161b29ff"
+      },
+      {
+        "key": "title_font_ios",
+        "type": "ios_font_selector",
+        "label": "iOS title font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "title_font_android",
+        "type": "android_font_selector",
+        "label": "Android title font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "title_font_size",
+        "type": "number_input",
+        "label": "Title font size",
+        "initial_value": 15
+      },
+      {
+        "key": "title_font_color",
+        "type": "color_picker",
+        "label": "Title font color",
+        "initial_value": "#ffffffff"
+      },
+      {
+        "key": "back_button_font_ios",
+        "type": "ios_font_selector",
+        "label": "iOS back button font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "back_button_font_android",
+        "type": "android_font_selector",
+        "label": "Android back button font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "back_button_font_size",
+        "type": "number_input",
+        "label": "Back button font size",
+        "initial_value": 15
+      },
+      {
+        "key": "back_button_font_color",
+        "type": "color_picker",
+        "label": "Back button font color",
+        "initial_value": "#ffffffff"
+      },
+      {
+        "key": "fields_font_ios",
+        "type": "ios_font_selector",
+        "label": "iOS input fields title font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "fields_font_android",
+        "type": "android_font_selector",
+        "label": "Android input fields title font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "fields_font_size",
+        "type": "number_input",
+        "label": "Input fields title font size",
+        "initial_value": 13
+      },
+      {
+        "key": "fields_font_color",
+        "type": "color_picker",
+        "label": "Input fields font color",
+        "initial_value": "#ffffffff"
+      },
+      {
+        "key": "fields_placeholder_font_color",
+        "type": "color_picker",
+        "label": "Input fields placeholder font color",
+        "initial_value": "#ffffffff"
+      },
+      {
+        "key": "fields_separator_color",
+        "type": "color_picker",
+        "label": "Input fields separator color",
+        "initial_value": "#a9a9a9ff"
+      },
+      {
+        "key": "forgot_password_font_ios",
+        "type": "ios_font_selector",
+        "label": "iOS forgot password font",
+        "initial_value": "Roboto-Regular"
+      },
+      {
+        "key": "forgot_password_font_android",
+        "type": "android_font_selector",
+        "label": "Android forgot password font",
+        "initial_value": "Roboto-Regular"
+      },
+      {
+        "key": "forgot_password_font_size",
+        "type": "number_input",
+        "label": "Forgot password font size",
+        "initial_value": 11
+      },
+      {
+        "key": "forgot_password_font_color",
+        "type": "color_picker",
+        "label": "Forgot password font color",
+        "initial_value": "#a9a9a9ff"
+      },
+      {
+        "key": "action_button_background_color",
+        "type": "color_picker",
+        "label": "iOS action button background color",
+        "initial_value": "#f1af13ff"
+      },
+      {
+        "key": "action_button_font_ios",
+        "type": "ios_font_selector",
+        "label": "iOS action button font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "action_button_font_android",
+        "type": "android_font_selector",
+        "label": "Android action button font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "action_button_font_size",
+        "type": "number_input",
+        "label": "Action button font size",
+        "initial_value": 15
+      },
+      {
+        "key": "action_button_font_color",
+        "type": "color_picker",
+        "label": "Action button font Color",
+        "initial_value": "#ffffffff"
+      },
+      {
+        "key": "create_account_link_font_ios",
+        "type": "ios_font_selector",
+        "label": "iOS Create account link font",
+        "initial_value": "Roboto-Regular"
+      },
+      {
+        "key": "create_account_link_font_android",
+        "type": "android_font_selector",
+        "label": "Android Create account link font",
+        "initial_value": "Roboto-Regular"
+      },
+      {
+        "key": "create_account_link_font_size",
+        "type": "number_input",
+        "label": "Create account link font size",
+        "initial_value": 11
+      },
+      {
+        "key": "create_account_link_font_color",
+        "type": "color_picker",
+        "label": "Create account link font color",
+        "initial_value": "#a9a9a9ff"
+      },
+      {
+        "key": "logout_background_color",
+        "type": "color_picker",
+        "label": "Logout background font color",
+        "initial_value": "#161b29ff"
+      },
+      {
+        "key": "logout_title_font_ios",
+        "type": "ios_font_selector",
+        "label": "Logout iOS title font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "logout_title_font_android",
+        "type": "android_font_selector",
+        "label": "Logout Android title font",
+        "initial_value": "Roboto-Bold"
+      },
+      {
+        "key": "logout_title_font_size",
+        "type": "number_input",
+        "label": "Logout title font size",
+        "initial_value": 15
+      },
+      {
+        "key": "logout_title_font_color",
+        "type": "color_picker",
+        "label": "Logout title font color",
+        "initial_value": "#ffffffff"
+      },
+      {
+        "group": true,
+        "label": "Storefront Screen Design and Text",
+        "tooltip": "These fields affect the design of the storefront screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "payment_screen_background",
+            "type": "color_picker_rgba",
+            "label": "Payment Screen Background Color",
+            "label_tooltip": "Background Color for the payment screen.",
+            "initial_value": "rgba(66,74,87,1)"
+          },
+          {
+            "key": "close_button",
+            "type": "uploader",
+            "label": "Close Button",
+            "label_tooltip": "Icon for close button. Dimensions 45 x 45.",
+            "placeholder": "W 45px x H 45px"
+          },
+          {
+            "key": "client_logo",
+            "type": "uploader",
+            "label": "Client Logo",
+            "label_tooltip": "Client logo image. Dimension 200 x44.",
+            "placeholder": "W 200px x H 44px"
+          },
+          {
+            "key": "payment_screen_title_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for Main Title for ios.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "payment_screen_title_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Main Title for android.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "payment_screen_title_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Main Title Text.",
+            "initial_value": "21"
+          },
+          {
+            "key": "payment_screen_title_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Main Title Text.",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "restore_purchases_text_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for Restore Purchases Description Text for ios.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "restore_purchases_text_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Restore Purchases Description Text for android.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "restore_purchases_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Restore Purchases Description Text.",
+            "initial_value": "12"
+          },
+          {
+            "key": "restore_purchases_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Restore Purchases Description Text.",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "restore_purchases_link_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for Restore Purchases Link Text for ios.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "restore_purchases_link_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Restore Purchases Link Text for android.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "restore_purchases_link_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Restore Purchases Link Text.",
+            "initial_value": "13"
+          },
+          {
+            "key": "restore_purchases_link_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Restore Purchases Link Text.",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "payment_option_background",
+            "type": "color_picker_rgba",
+            "label": "Payment Option Background Color",
+            "label_tooltip": "Background Color for the Payment Option.",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "payment_option_corner_radius",
+            "type": "number_input",
+            "label": "Payment Option Corner Radius",
+            "label_tooltip": "Corner Radius for the Payment Option.",
+            "initial_value": "6"
+          },
+          {
+            "key": "payment_option_title_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for the Payment Option Title for ios.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "payment_option_title_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Payment Option Title for android.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "payment_option_title_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Payment Option Title.",
+            "initial_value": "20"
+          },
+          {
+            "key": "payment_option_title_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Payment Option Title.",
+            "initial_value": "rgba(0,0,0,1)"
+          },
+          {
+            "key": "payment_option_description_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for the Payment Option Description for ios.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "payment_option_description_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Payment Option Description for android.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "payment_option_description_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Payment Option Description.",
+            "initial_value": "14"
+          },
+          {
+            "key": "payment_option_description_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Payment Option Description.",
+            "initial_value": "rgba(66,74,87,1)"
+          },
+          {
+            "key": "payment_option_button_background",
+            "type": "color_picker_rgba",
+            "label": "Payment Option Action Button Background Color",
+            "label_tooltip": "Background Color for the Payment Option Action Button.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "payment_option_button_corner_radius",
+            "type": "number_input",
+            "label": "Payment Option Action Button Corner Radius",
+            "label_tooltip": "Corner Radius for the Payment Option Action Button.",
+            "initial_value": "18"
+          },
+          {
+            "key": "payment_option_button_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for the Payment Option Action Button Text for ios.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "payment_option_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Payment Option Action Button Text for android.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "payment_option_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Payment Option Action Button Text.",
+            "initial_value": "12"
+          },
+          {
+            "key": "payment_option_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Payment Option Action Button Text.",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "terms_of_use_instructions_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for the Terms of Use Instructions Text for ios.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "terms_of_use_instructions_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Terms of Use Instructions Text for android.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "terms_of_use_instructions_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for the Terms of Use Instructions Text.",
+            "initial_value": "10"
+          },
+          {
+            "key": "terms_of_use_instructions_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for the Terms of Use Instructions Text.",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "terms_of_use_link",
+            "type": "text_input",
+            "label": "Payment Terms of use Link",
+            "label_tooltip": "Link for the Terms of Use.",
+            "initial_value": "http://google.com"
+          },
+          {
+            "key": "terms_of_use_link_font_ios",
+            "type": "ios_font_selector",
+            "label_tooltip": "Font for the Terms of Use Link Text for ios.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "terms_of_use_link_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Terms of Use Link Text for android.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "terms_of_use_link_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for the Terms of Use Link Text.",
+            "initial_value": "10"
+          },
+          {
+            "key": "terms_of_use_link_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for the Terms of Use Link Text.",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          }
+        ]
+      }
+    ]
+  },
+  "localizations": {
+    "fields": [
+      {
+        "key": "fields_email_text",
+        "label": "Email field placeholder",
+        "initial_value": "E-mail"
+      },
+      {
+        "key": "fields_password_text",
+        "label": "Password field placeholder",
+        "initial_value": "Password"
+      },
+      {
+        "key": "fields_name_text",
+        "label": "Name field placeholder",
+        "initial_value": "Enter your name"
+      },
+      {
+        "key": "action_button_login_text",
+        "label": "Login button title",
+        "initial_value": "LOG IN"
+      },
+      {
+        "key": "action_button_signup_text",
+        "label": "Signup button title",
+        "initial_value": "SIGN UP"
+      },
+      {
+        "key": "video_stream_exception_message",
+        "label": "Message in case video url is empty",
+        "initial_value": "Video stream in not available. Please try again later"
+      },
+      {
+        "key": "general_error_message",
+        "label": "General error message",
+        "initial_value": "Something went wrong. Please try again later"
+      },
+      {
+        "key": "signup_title_error_text",
+        "label": "Error signup title",
+        "initial_value": "Sign-up failed"
+      },
+      {
+        "key": "login_title_error_text",
+        "label": "Error login title",
+        "initial_value": "Login failed"
+      },
+      {
+        "key": "logout_title_succeed_text",
+        "label": "Successful logout title",
+        "initial_value": "Successfully Logged Out"
+      },
+      {
+        "key": "logout_title_fail_text",
+        "label": "Error logout title",
+        "initial_value": "Logout Failed"
+      },
+      {
+        "key": "reset_password_success_title",
+        "label": "Successful password reset title",
+        "initial_value": "Set New Password Success"
+      },
+      {
+        "key": "reset_password_success_text",
+        "label": "Successful password reset message",
+        "initial_value": "Your password was successfully updated"
+      },
+      {
+        "key": "reset_password_error_title",
+        "label": "Password reset error title",
+        "initial_value": "Set New Password"
+      },
+      {
+        "key": "reset_password_error_text",
+        "label": "Password reset error message",
+        "initial_value": "New password could not be set. Please try again."
+      },
+      {
+        "key": "request_password_success_title",
+        "label": "Successful password request title",
+        "initial_value": "Request Password Success"
+      },
+      {
+        "key": "request_password_error_title",
+        "label": "Password request error title",
+        "initial_value": "Request Password Fail"
+      },
+      {
+        "key": "request_password_error_text",
+        "label": "Password request error message",
+        "initial_value": "Can not request password"
+      },
+      {
+        "key": "login_title_validation_error",
+        "label": "Login validation error title",
+        "initial_value": "Login form issue"
+      },
+      {
+        "key": "signup_title_validation_error",
+        "label": "Signup validation error title",
+        "initial_value": "Sign Up form issue"
+      },
+      {
+        "key": "new_password_title_validation_error",
+        "label": "New password validation error title",
+        "initial_value": "Set New Password form issue"
+      },
+      {
+        "key": "login_email_validation_error",
+        "label": "Error message for not valid EMAIL",
+        "initial_value": "Email is not valid"
+      },
+      {
+        "key": "signup_name_validation_error",
+        "label": "Error message for not valid NAME",
+        "initial_value": "Name can not be empty"
+      },
+      {
+        "key": "signup_password_validation_error",
+        "label": "Error message for not valid PASSWORD",
+        "initial_value": "Password must be at least 8 characters and contain one lower case, one upper case, one special character and one number"
+      },
+      {
+        "key": "signup_password_confirmation_validation_error",
+        "label": "Error message for not valid PASSWORD CONFIRMATION",
+        "initial_value": "Password not equal confirmation password"
+      },
+      {
+        "key": "new_password_token_validation_error",
+        "label": "Error message for not valid TOKEN",
+        "initial_value": "Token should not be empty"
+      },
+      {
+        "key": "title_font_text",
+        "label": "Text title",
+        "initial_value": "InPlayer"
+      },
+      {
+        "key": "back_button_text",
+        "label": "Back button title",
+        "initial_value": "Back"
+      },
+      {
+        "key": "fields_set_new_password_text",
+        "label": "New password field placeholder",
+        "initial_value": "New password"
+      },
+      {
+        "key": "fields_password_confirmation_text",
+        "label": "Password confirmation field placeholder",
+        "initial_value": "Password Confirmation"
+      },
+      {
+        "key": "fields_token_text",
+        "label": "Token field placeholder",
+        "initial_value": "Token"
+      },
+      {
+        "key": "forgot_password_text",
+        "label": "Forgot password text",
+        "initial_value": "Forgotten your Username or Password?"
+      },
+      {
+        "key": "create_account_link_text",
+        "label": "Create account text",
+        "initial_value": "No user? Sign Up!"
+      },
+      {
+        "key": "action_button_forgot_password_text",
+        "label": "Request password button title",
+        "initial_value": "REQUEST PASSWORD"
+      },
+      {
+        "key": "action_button_set_new_password_text",
+        "label": "Set new password button title",
+        "initial_value": "SET NEW PASSWORD"
+      },
+      {
+        "key": "payment_screen_title_text",
+        "label": "Payment screen title",
+        "initial_value": "Choose Your Subscription"
+      },
+      {
+        "key": "restore_purchases_text",
+        "label": "Restore purchases description",
+        "initial_value": "Purchased already a subscription?"
+      },
+      {
+        "key": "restore_purchases_link",
+        "label": "Restore purchases text",
+        "initial_value": "Restore"
+      },
+      {
+        "key": "terms_of_use_instructions_text",
+        "label": "Payment terms of use instruction",
+        "initial_value": "By making a selection and completing this transaction, you verify that you are at least 18 years old and agree to the"
+      },
+      {
+        "key": "terms_of_use_link_text",
+        "label": "Payment terms of use text",
+        "initial_value": "terms of use."
+      }
+    ]
+  },
+  "targets": [
+    "mobile"
+  ]
+}

--- a/plugins/login-plugin/manifests/lg_tv.json
+++ b/plugins/login-plugin/manifests/lg_tv.json
@@ -116,6 +116,7 @@
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [],
+  "min_zapp_sdk": "1.0.0",
   "npm_dependencies": [
     "@applicaster/applicaster-iap@0.3.3",
     "@react-native-community/blur@3.4.1"

--- a/plugins/login-plugin/manifests/localizations.config.js
+++ b/plugins/login-plugin/manifests/localizations.config.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const common = [
   // Fields
   {

--- a/plugins/login-plugin/manifests/manifest.config.js
+++ b/plugins/login-plugin/manifests/manifest.config.js
@@ -1985,6 +1985,7 @@ const min_zapp_sdk = {
   android_tv_for_quickbrick: "0.1.0-alpha1",
   amazon_fire_tv_for_quickbrick: "0.1.0-alpha1",
   samsung_tv: "1.2.2",
+  lg_tv: "1.0.0",
 };
 
 const isApple = R.includes(R.__, applePlatforms);

--- a/plugins/login-plugin/manifests/samsung_tv.json
+++ b/plugins/login-plugin/manifests/samsung_tv.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "3.0.17",
-  "manifest_version": "3.0.17",
+  "dependency_version": "3.0.18",
+  "manifest_version": "3.0.18",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/login-plugin/manifests/tvos_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/tvos_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "3.0.17",
-  "manifest_version": "3.0.17",
+  "dependency_version": "3.0.18",
+  "manifest_version": "3.0.18",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/login-plugin/package.json
+++ b/plugins/login-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/login-plugin/package.json
+++ b/plugins/login-plugin/package.json
@@ -39,7 +39,8 @@
       "tvos_for_quickbrick",
       "android_tv_for_quickbrick",
       "amazon_fire_tv_for_quickbrick",
-      "samsung_tv"
+      "samsung_tv",
+      "lg_tv"
     ],
     "zappOwnerAccountId": "5e12fac7666333000ec0f8ab"
   }


### PR DESCRIPTION
This PR helps address an issue we are experiencing with the QuickBrick framework where we were getting babel and webpack parsing errors because of the shebang on the top of the localization file:

```
ERROR in ../node_modules/@applicaster/quick-brick-inplayer/manifests/localizations.config.js 1:0
Module parse failed: Unexpected character '#' (1:0)
File was processed with these loaders:
 * ../node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
> #!/usr/bin/env node
| "use strict";(function(){var enterModule=typeof reactHotLoaderGlobal!=='undefined'?reactHotLoaderGlobal.enterModule:undefined;enterModule&&enterModule(module);})();var __signature__=typeof reactHotLoaderGlobal!=='undefined'?reactHotLoaderGlobal.default.signature:function(a){return a;};var common=[// Fields
| {key:"fields_email_text",label:"Email field placeholder",initial_value:"E-mail"},{key:"fields_password_text",label:"Password field placeholder",initial_value:"Password"},{key:"fields_name_text",label:"Name field placeholder",initial_value:"Enter your name"},// Action buttons
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Utils/Localizations/index.js 1:321-371
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/InPlayer.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/index.js
 @ ./index.js
 @ multi @babel/polyfill ./index.js
```

Removing the shebang seems to solve the first part of it.


#### Update

After fixing the issues with the shebang, started getting additional build errors with LG version of the plugin. 

```
ERROR in ../node_modules/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareHOC.js 14:12
Module parse failed: Unexpected token (14:12)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| } from 'react-native'
| import { isIphoneX } from 'react-native-iphone-x-helper'
> import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
|
| const _KAM_DEFAULT_TAB_BAR_HEIGHT: number = isIphoneX() ? 83 : 49
 @ ../node_modules/react-native-keyboard-aware-scroll-view/index.js 3:0-59 8:0-13:1
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/Login/LoginMobile/index.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/Login/index.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/AccountFlow/index.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/InPlayer.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/index.js
 @ ./index.js
 @ multi @babel/polyfill ./index.js
ERROR in ../node_modules/@applicaster/applicaster-iap/src/index.js 14:32
Module parse failed: Unexpected token (14:32)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|
|   async isInitialized() {
>     return ApplicasterIAPBridge?.isInitialized?.();
|   },
|
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Services/iAPService.js 1:334-373
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/AssetFlow/index.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/InPlayer.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/index.js
 @ ./index.js
 @ multi @babel/polyfill ./index.js
ERROR in ../node_modules/react-native-dropdownalert/DropdownAlert.js 28:19
Module parse failed: Unexpected token (28:19)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|
| export default class DropdownAlert extends Component {
>   static propTypes = {
|     imageSrc: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
|     infoImageSrc: PropTypes.oneOfType([
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/AccountFlow/index.js 1:627-664
 @ ../node_modules/@applicaster/quick-brick-inplayer/src/Components/InPlayer.js
 @ ../node_modules/@applicaster/quick-brick-inplayer/index.js
 @ ./index.js
 @ multi @babel/polyfill ./index.js
 ```
 
 Later found out that this is because we were not excluding native packages from the LG application, while in Samsung we were. This is because the `manifest.config.js` did not have LG listed as a web / tv app.
 
 The subsequent commits add LG as a web / tv app therefore it inherited all of the properties that Samsung had.