### PR TITLE
fix: lg missing styles from manifest

### DIFF
--- a/plugins/login-plugin/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/amazon_fire_tv_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "3.0.18",
-  "manifest_version": "3.0.18",
+  "dependency_version": "3.0.19",
+  "manifest_version": "3.0.19",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/android_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/android_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "3.0.18",
-  "manifest_version": "3.0.18",
+  "dependency_version": "3.0.19",
+  "manifest_version": "3.0.19",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/android_tv_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/android_tv_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "3.0.18",
-  "manifest_version": "3.0.18",
+  "dependency_version": "3.0.19",
+  "manifest_version": "3.0.19",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/ios_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/ios_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "3.0.18",
-  "manifest_version": "3.0.18",
+  "dependency_version": "3.0.19",
+  "manifest_version": "3.0.19",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/login-plugin/manifests/lg_tv.json
+++ b/plugins/login-plugin/manifests/lg_tv.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "lg_tv",
-  "dependency_version": "3.0.18",
-  "manifest_version": "3.0.18",
+  "dependency_version": "3.0.19",
+  "manifest_version": "3.0.19",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [],

--- a/plugins/login-plugin/manifests/samsung_tv.json
+++ b/plugins/login-plugin/manifests/samsung_tv.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "3.0.18",
-  "manifest_version": "3.0.18",
+  "dependency_version": "3.0.19",
+  "manifest_version": "3.0.19",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/login-plugin/manifests/tvos_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/tvos_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "3.0.18",
-  "manifest_version": "3.0.18",
+  "dependency_version": "3.0.19",
+  "manifest_version": "3.0.19",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/login-plugin/package.json
+++ b/plugins/login-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/login-plugin/src/Utils/Customization/index.js
+++ b/plugins/login-plugin/src/Utils/Customization/index.js
@@ -17,7 +17,7 @@ const manifestJson = () => {
       default: require("../../../manifests/android.json"),
     });
   } catch (error) {
-    console.warn("Could not load manifest", error);
+    throw new Error("Could not load manifest at inplayer login plugin.", error);
   }
 };
 

--- a/plugins/login-plugin/src/Utils/Customization/index.js
+++ b/plugins/login-plugin/src/Utils/Customization/index.js
@@ -4,19 +4,25 @@ import { platformSelect } from "@applicaster/zapp-react-native-utils/reactUtils"
 import { populateConfigurationValues } from "@applicaster/zapp-react-native-utils/stylesUtils";
 import MESSAGES from "../../Components/AssetFlow/Config";
 
-const manifestJson = platformSelect({
-  ios: require("../../../manifests/ios_for_quickbrick.json"),
-  tvos: require("../../../manifests/tvos_for_quickbrick.json"),
-  android: require("../../../manifests/android.json"),
-  android_tv: require("../../../manifests/android_tv_for_quickbrick.json"),
-  web: require("../../../manifests/samsung_tv.json"),
-  samsung_tv: require("../../../manifests/samsung_tv.json"),
-  // lg_tv: require("../../../manifests/lg_tv.json"),
-  default: require("../../../manifests/android.json"),
-});
+const manifestJson = () => {
+  try {
+    return platformSelect({
+      ios: require("../../../manifests/ios_for_quickbrick.json"),
+      tvos: require("../../../manifests/tvos_for_quickbrick.json"),
+      android: require("../../../manifests/android.json"),
+      android_tv: require("../../../manifests/android_tv_for_quickbrick.json"),
+      web: require("../../../manifests/samsung_tv.json"),
+      samsung_tv: require("../../../manifests/samsung_tv.json"),
+      lg_tv: require("../../../manifests/lg_tv.json"),
+      default: require("../../../manifests/android.json"),
+    });
+  } catch (error) {
+    console.warn("Could not load manifest", error);
+  }
+};
 
 export function pluginIdentifier() {
-  return manifestJson.identifier;
+  return manifestJson().identifier;
 }
 
 export let styles = null;
@@ -25,7 +31,7 @@ export function getStyles(screenStyles) {
 }
 
 export function prepareStyles(screenStyles) {
-  styles = populateConfigurationValues(manifestJson.styles.fields)(
+  styles = populateConfigurationValues(manifestJson().styles.fields)(
     screenStyles
   );
   styles.import_parent_lock = screenStyles.import_parent_lock


### PR DESCRIPTION
This PR adds some functionality that was missing for the LG platforms, because there was never a manifest for these platforms the default style keys never were populated as in the other platforms.

This PR adds the manifest, and publishes a new version of the plugin. 

### Known Issue:

In order to make buttons and inputs work with the LG Remote we would need to make the changes on @applicaster/QuickBrick repo.