### PR TITLE
fix: manifest config now includes LG as a web platform

### DIFF
--- a/plugins/login-plugin/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/amazon_fire_tv_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "3.1.1",
-  "manifest_version": "3.1.1",
+  "dependency_version": "3.1.4",
+  "manifest_version": "3.1.4",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/android_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/android_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "3.1.1",
-  "manifest_version": "3.1.1",
+  "dependency_version": "3.1.4",
+  "manifest_version": "3.1.4",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/android_tv_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/android_tv_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "3.1.1",
-  "manifest_version": "3.1.1",
+  "dependency_version": "3.1.4",
+  "manifest_version": "3.1.4",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/login-plugin/manifests/ios_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/ios_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "3.1.1",
-  "manifest_version": "3.1.1",
+  "dependency_version": "3.1.4",
+  "manifest_version": "3.1.4",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/login-plugin/manifests/lg_tv.json
+++ b/plugins/login-plugin/manifests/lg_tv.json
@@ -10,7 +10,9 @@
   "react_native": true,
   "identifier": "quick-brick-inplayer",
   "ui_builder_support": true,
-  "whitelisted_account_ids": ["5c9ce7917b225c000f02dfbc"],
+  "whitelisted_account_ids": [
+    "5c9ce7917b225c000f02dfbc"
+  ],
   "deprecated_since_zapp_sdk": "",
   "unsupported_since_zapp_sdk": "",
   "preload": true,
@@ -105,10 +107,12 @@
       }
     ]
   },
-  "ui_frameworks": ["quickbrick"],
+  "ui_frameworks": [
+    "quickbrick"
+  ],
   "platform": "lg_tv",
-  "dependency_version": "3.1.1",
-  "manifest_version": "3.1.1",
+  "dependency_version": "3.1.4",
+  "manifest_version": "3.1.4",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",
@@ -118,7 +122,7 @@
   },
   "project_dependencies": [],
   "extra_dependencies": [],
-  "min_zapp_sdk": "1.2.2",
+  "min_zapp_sdk": "1.2.0",
   "npm_dependencies": [],
   "styles": {
     "fields": [
@@ -883,7 +887,9 @@
             "initial_value": "rgba(39, 218, 134, 1)",
             "conditional_fields": [
               {
-                "condition_value": [true],
+                "condition_value": [
+                  true
+                ],
                 "key": "general/enable_skip_functionality"
               }
             ]
@@ -895,7 +901,9 @@
             "initial_value": "Helvetica-Bold",
             "conditional_fields": [
               {
-                "condition_value": [true],
+                "condition_value": [
+                  true
+                ],
                 "key": "general/enable_skip_functionality"
               }
             ]
@@ -907,7 +915,9 @@
             "initial_value": "Roboto-Bold",
             "conditional_fields": [
               {
-                "condition_value": [true],
+                "condition_value": [
+                  true
+                ],
                 "key": "general/enable_skip_functionality"
               }
             ]
@@ -919,7 +929,9 @@
             "initial_value": "40",
             "conditional_fields": [
               {
-                "condition_value": [true],
+                "condition_value": [
+                  true
+                ],
                 "key": "general/enable_skip_functionality"
               }
             ]
@@ -931,7 +943,9 @@
             "initial_value": "#545A5C",
             "conditional_fields": [
               {
-                "condition_value": [true],
+                "condition_value": [
+                  true
+                ],
                 "key": "general/enable_skip_functionality"
               }
             ]
@@ -1598,5 +1612,7 @@
       }
     ]
   },
-  "targets": ["tv"]
+  "targets": [
+    "tv"
+  ]
 }

--- a/plugins/login-plugin/manifests/lg_tv.json
+++ b/plugins/login-plugin/manifests/lg_tv.json
@@ -10,9 +10,7 @@
   "react_native": true,
   "identifier": "quick-brick-inplayer",
   "ui_builder_support": true,
-  "whitelisted_account_ids": [
-    "5c9ce7917b225c000f02dfbc"
-  ],
+  "whitelisted_account_ids": ["5c9ce7917b225c000f02dfbc"],
   "deprecated_since_zapp_sdk": "",
   "unsupported_since_zapp_sdk": "",
   "preload": true,
@@ -107,473 +105,1295 @@
       }
     ]
   },
-  "ui_frameworks": [
-    "quickbrick"
-  ],
+  "ui_frameworks": ["quickbrick"],
   "platform": "lg_tv",
   "dependency_version": "3.1.1",
   "manifest_version": "3.1.1",
-  "api": {},
+  "api": {
+    "excludedNodeModules": [
+      "@applicaster/applicaster-iap",
+      "react-native-dropdownalert",
+      "react-native-keyboard-aware-scroll-view"
+    ]
+  },
   "project_dependencies": [],
   "extra_dependencies": [],
-  "min_zapp_sdk": "1.0.0",
-  "npm_dependencies": [
-    "@applicaster/applicaster-iap@1.1.1",
-    "@react-native-community/blur@3.4.1"
-  ],
+  "min_zapp_sdk": "1.2.2",
+  "npm_dependencies": [],
   "styles": {
     "fields": [
       {
-        "key": "background_color",
-        "type": "color_picker",
-        "label": "Background font color",
-        "initial_value": "#161b29ff"
-      },
-      {
-        "key": "title_font_ios",
-        "type": "ios_font_selector",
-        "label": "iOS title font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "title_font_android",
-        "type": "android_font_selector",
-        "label": "Android title font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "title_font_size",
-        "type": "number_input",
-        "label": "Title font size",
-        "initial_value": 15
-      },
-      {
-        "key": "title_font_color",
-        "type": "color_picker",
-        "label": "Title font color",
-        "initial_value": "#ffffffff"
-      },
-      {
-        "key": "back_button_font_ios",
-        "type": "ios_font_selector",
-        "label": "iOS back button font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "back_button_font_android",
-        "type": "android_font_selector",
-        "label": "Android back button font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "back_button_font_size",
-        "type": "number_input",
-        "label": "Back button font size",
-        "initial_value": 15
-      },
-      {
-        "key": "back_button_font_color",
-        "type": "color_picker",
-        "label": "Back button font color",
-        "initial_value": "#ffffffff"
-      },
-      {
-        "key": "fields_font_ios",
-        "type": "ios_font_selector",
-        "label": "iOS input fields title font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "fields_font_android",
-        "type": "android_font_selector",
-        "label": "Android input fields title font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "fields_font_size",
-        "type": "number_input",
-        "label": "Input fields title font size",
-        "initial_value": 13
-      },
-      {
-        "key": "fields_font_color",
-        "type": "color_picker",
-        "label": "Input fields font color",
-        "initial_value": "#ffffffff"
-      },
-      {
-        "key": "fields_placeholder_font_color",
-        "type": "color_picker",
-        "label": "Input fields placeholder font color",
-        "initial_value": "#ffffffff"
-      },
-      {
-        "key": "fields_separator_color",
-        "type": "color_picker",
-        "label": "Input fields separator color",
-        "initial_value": "#a9a9a9ff"
-      },
-      {
-        "key": "forgot_password_font_ios",
-        "type": "ios_font_selector",
-        "label": "iOS forgot password font",
-        "initial_value": "Roboto-Regular"
-      },
-      {
-        "key": "forgot_password_font_android",
-        "type": "android_font_selector",
-        "label": "Android forgot password font",
-        "initial_value": "Roboto-Regular"
-      },
-      {
-        "key": "forgot_password_font_size",
-        "type": "number_input",
-        "label": "Forgot password font size",
-        "initial_value": 11
-      },
-      {
-        "key": "forgot_password_font_color",
-        "type": "color_picker",
-        "label": "Forgot password font color",
-        "initial_value": "#a9a9a9ff"
-      },
-      {
-        "key": "action_button_background_color",
-        "type": "color_picker",
-        "label": "iOS action button background color",
-        "initial_value": "#f1af13ff"
-      },
-      {
-        "key": "action_button_font_ios",
-        "type": "ios_font_selector",
-        "label": "iOS action button font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "action_button_font_android",
-        "type": "android_font_selector",
-        "label": "Android action button font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "action_button_font_size",
-        "type": "number_input",
-        "label": "Action button font size",
-        "initial_value": 15
-      },
-      {
-        "key": "action_button_font_color",
-        "type": "color_picker",
-        "label": "Action button font Color",
-        "initial_value": "#ffffffff"
-      },
-      {
-        "key": "create_account_link_font_ios",
-        "type": "ios_font_selector",
-        "label": "iOS Create account link font",
-        "initial_value": "Roboto-Regular"
-      },
-      {
-        "key": "create_account_link_font_android",
-        "type": "android_font_selector",
-        "label": "Android Create account link font",
-        "initial_value": "Roboto-Regular"
-      },
-      {
-        "key": "create_account_link_font_size",
-        "type": "number_input",
-        "label": "Create account link font size",
-        "initial_value": 11
-      },
-      {
-        "key": "create_account_link_font_color",
-        "type": "color_picker",
-        "label": "Create account link font color",
-        "initial_value": "#a9a9a9ff"
-      },
-      {
-        "key": "logout_background_color",
-        "type": "color_picker",
-        "label": "Logout background font color",
-        "initial_value": "#161b29ff"
-      },
-      {
-        "key": "logout_title_font_ios",
-        "type": "ios_font_selector",
-        "label": "Logout iOS title font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "logout_title_font_android",
-        "type": "android_font_selector",
-        "label": "Logout Android title font",
-        "initial_value": "Roboto-Bold"
-      },
-      {
-        "key": "logout_title_font_size",
-        "type": "number_input",
-        "label": "Logout title font size",
-        "initial_value": 15
-      },
-      {
-        "key": "logout_title_font_color",
-        "type": "color_picker",
-        "label": "Logout title font color",
-        "initial_value": "#ffffffff"
+        "key": "client_logo",
+        "type": "uploader",
+        "label": "Client Logo",
+        "label_tooltip": "Client logo image. Dimension 200 x44.",
+        "placeholder": "W 200px x H 44px"
       },
       {
         "group": true,
-        "label": "Storefront Screen Design and Text",
-        "tooltip": "These fields affect the design of the storefront screen.",
+        "label": "Logout Screen",
+        "tooltip": "This fields affect logout screen.",
         "folded": true,
         "fields": [
           {
-            "key": "payment_screen_background",
+            "key": "logout_background_color",
+            "type": "color_picker",
+            "label": "Logout background font color",
+            "initial_value": "#161b29ff"
+          },
+          {
+            "key": "logout_title_font_tvos",
+            "type": "tvos_font_selector",
+            "label": "Logout tvOS title font",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "logout_title_font_android_tv",
+            "type": "android_font_selector",
+            "label": "Logout Android title font",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "logout_title_font_size",
+            "type": "number_input",
+            "label": "Logout title font size",
+            "initial_value": 30
+          },
+          {
+            "key": "logout_title_font_color",
+            "type": "color_picker",
+            "label": "Logout title font color",
+            "initial_value": "#ffffffff"
+          }
+        ]
+      },
+      {
+        "group": true,
+        "label": "Subscriber Agreement Design and Text",
+        "tooltip": "These fields affect the design of the subscriber agreement screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "privacy_screen_background_color",
             "type": "color_picker_rgba",
-            "label": "Payment Screen Background Color",
+            "label": "Background Color for the payment screen.",
             "label_tooltip": "Background Color for the payment screen.",
-            "initial_value": "rgba(66,74,87,1)"
+            "initial_value": "rgba(60, 65, 75, 1)"
           },
           {
-            "key": "close_button",
-            "type": "uploader",
-            "label": "Close Button",
-            "label_tooltip": "Icon for close button. Dimensions 45 x 45.",
-            "placeholder": "W 45px x H 45px"
-          },
-          {
-            "key": "client_logo",
-            "type": "uploader",
-            "label": "Client Logo",
-            "label_tooltip": "Client logo image. Dimension 200 x44.",
-            "placeholder": "W 200px x H 44px"
-          },
-          {
-            "key": "payment_screen_title_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for Main Title for ios.",
-            "initial_value": "Roboto-Bold"
-          },
-          {
-            "key": "payment_screen_title_font_android",
-            "type": "android_font_selector",
-            "label_tooltip": "Font for Main Title for android.",
-            "initial_value": "Roboto-Bold"
-          },
-          {
-            "key": "payment_screen_title_fontsize",
-            "type": "number_input",
-            "label_tooltip": "Font Size for Main Title Text.",
-            "initial_value": "21"
-          },
-          {
-            "key": "payment_screen_title_fontcolor",
+            "key": "privacy_text_area_background_color",
             "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for Main Title Text.",
+            "label": "Background Color for the text area where the Agreement and Privacy are shown.",
+            "label_tooltip": "Background Color for the text area where the Agreement and Privacy are shown.",
+            "initial_value": "rgba(54, 60, 71, 1)"
+          },
+          {
+            "key": "privacy_main_title_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Main Title for the agreement and privacy screen for Android TV.",
+            "initial_value": "Roboto-Dark"
+          },
+          {
+            "key": "privacy_main_title_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the Main Title for the agreement and privacy screen for TvOS.",
+            "initial_value": "HelveticaNeue-Bold"
+          },
+          {
+            "key": "privacy_main_title_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size Main Title for the agreement and privacy screen.",
+            "initial_value": "50"
+          },
+          {
+            "key": "privacy_main_title_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color Main Title for the agreement and privacy screen",
             "initial_value": "rgba(255, 255, 255, 1)"
           },
           {
-            "key": "restore_purchases_text_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for Restore Purchases Description Text for ios.",
-            "initial_value": "Roboto-Regular"
-          },
-          {
-            "key": "restore_purchases_text_font_android",
+            "key": "privacy_text_font_android_tv",
             "type": "android_font_selector",
-            "label_tooltip": "Font for Restore Purchases Description Text for android.",
-            "initial_value": "Roboto-Regular"
+            "label_tooltip": "Font for the text for the agreement and privacy screen for Android TV.",
+            "initial_value": "Roboto-Medium"
           },
           {
-            "key": "restore_purchases_text_fontsize",
+            "key": "privacy_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the text for the agreement and privacy screen for TvOS.",
+            "initial_value": "HelveticaNeue-Medium"
+          },
+          {
+            "key": "privacy_text_fontsize",
             "type": "number_input",
-            "label_tooltip": "Font Size for Restore Purchases Description Text.",
-            "initial_value": "12"
+            "label_tooltip": "Font Size text for the agreement and privacy screen.",
+            "initial_value": "30"
           },
           {
-            "key": "restore_purchases_text_fontcolor",
+            "key": "privacy_text_fontcolor",
             "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for Restore Purchases Description Text.",
+            "label_tooltip": "Font Color text for the agreement and privacy screen",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          }
+        ]
+      },
+      {
+        "group": true,
+        "label": "StoreFront Design and Text",
+        "tooltip": "These fields affect the design of the storefront screen plugin.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "storefront_screen_background_color",
+            "type": "color_picker_rgba",
+            "label": "Storefront Screen Background Color",
+            "label_tooltip": "Background Color for the payment screen.",
+            "initial_value": "rgba(54, 61, 71, 1)"
+          },
+          {
+            "key": "subscription_default_title_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Main Title for the payment screen for Android TV.",
+            "initial_value": "Roboto-Dark"
+          },
+          {
+            "key": "subscription_default_title_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the Main Title for the payment screent for TvOS.",
+            "initial_value": "HelveticaNeue-Bold"
+          },
+          {
+            "key": "subscription_default_title_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size Main Title for the payment screen.",
+            "initial_value": "50"
+          },
+          {
+            "key": "subscription_default_title_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color Main Title for the payment screen",
             "initial_value": "rgba(255, 255, 255, 1)"
           },
           {
-            "key": "restore_purchases_link_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for Restore Purchases Link Text for ios.",
-            "initial_value": "Roboto-Bold"
+            "key": "event_schedule_text_date_format",
+            "type": "text_input",
+            "label": "Event Schedule ISO date format",
+            "label_tooltip": "Event Schedule ISO date format.",
+            "initial_value": "dddd, MMMM Do - hh:mm",
+            "placeholder": "Choose Your Subscription"
           },
           {
-            "key": "restore_purchases_link_font_android",
+            "key": "event_schedule_text_font_android_tv",
             "type": "android_font_selector",
-            "label_tooltip": "Font for Restore Purchases Link Text for android.",
-            "initial_value": "Roboto-Bold"
+            "label_tooltip": "Font for the Event Schedule for Android TV.",
+            "initial_value": "Roboto-Medium"
           },
           {
-            "key": "restore_purchases_link_fontsize",
+            "key": "event_schedule_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the Event Schedule for the payment screent for TvOS.",
+            "initial_value": "HelveticaNeue-Medium"
+          },
+          {
+            "key": "event_schedule_text_fontsize",
             "type": "number_input",
-            "label_tooltip": "Font Size for Restore Purchases Link Text.",
-            "initial_value": "13"
+            "label_tooltip": "Font for the Event Schedule for the payment screen.",
+            "initial_value": "24"
           },
           {
-            "key": "restore_purchases_link_fontcolor",
+            "key": "event_schedule_text_fontcolor",
             "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for Restore Purchases Link Text.",
+            "label_tooltip": "Font for the Event Schedule for the payment screen",
             "initial_value": "rgba(255, 255, 255, 1)"
           },
           {
-            "key": "payment_option_background",
+            "key": "subscription_default_description_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Description text for the subscription for Android TV.",
+            "initial_value": "Roboto-Dark"
+          },
+          {
+            "key": "subscription_default_description_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the Description text for the subscription for TvOS.",
+            "initial_value": "HelveticaNeue-Bold"
+          },
+          {
+            "key": "subscription_default_description_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font size for the Description text for the subscription",
+            "initial_value": "30"
+          },
+          {
+            "key": "subscription_default_description_text_fontcolor",
             "type": "color_picker_rgba",
-            "label": "Payment Option Background Color",
+            "label_tooltip": "Font Color for the Description text for the subscription",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "policy_agreement_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the policy agreement for Android TV.",
+            "initial_value": "Roboto-Medium"
+          },
+          {
+            "key": "policy_agreement_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the policy agreement for TvOS.",
+            "initial_value": "HelveticaNeue"
+          },
+          {
+            "key": "policy_agreement_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font size for the policy agreement",
+            "initial_value": "24"
+          },
+          {
+            "key": "policy_agreement_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for the policy agreement",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "payment_option_background_color",
+            "type": "color_picker_rgba",
             "label_tooltip": "Background Color for the Payment Option.",
-            "initial_value": "rgba(255, 255, 255, 1)"
+            "initial_value": "rgba(42, 45, 52, 1)"
+          },
+          {
+            "key": "payment_option_active_background_color",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for the Active Payment Option.",
+            "initial_value": "rgba(42, 45, 52, 1)"
           },
           {
             "key": "payment_option_corner_radius",
             "type": "number_input",
             "label": "Payment Option Corner Radius",
             "label_tooltip": "Corner Radius for the Payment Option.",
-            "initial_value": "6"
+            "initial_value": "10"
           },
           {
-            "key": "payment_option_title_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for the Payment Option Title for ios.",
-            "initial_value": "Roboto-Bold"
+            "key": "payment_option_active_border_color",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Border Color for the Active Payment Option.",
+            "initial_value": "rgba(42, 45, 52, 1)"
           },
           {
-            "key": "payment_option_title_font_android",
-            "type": "android_font_selector",
-            "label_tooltip": "Font for the Payment Option Title for android.",
-            "initial_value": "Roboto-Bold"
-          },
-          {
-            "key": "payment_option_title_fontsize",
+            "key": "payment_option_active_border_width",
             "type": "number_input",
-            "label_tooltip": "Font Size for Payment Option Title.",
-            "initial_value": "20"
+            "label": "Payment Option active border width",
+            "label_tooltip": "Width for the Active Payment Option.",
+            "initial_value": "3"
           },
           {
-            "key": "payment_option_title_fontcolor",
+            "key": "payment_option_default_action_background_color",
             "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for Payment Option Title.",
-            "initial_value": "rgba(0,0,0,1)"
-          },
-          {
-            "key": "payment_option_description_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for the Payment Option Description for ios.",
-            "initial_value": "Roboto-Regular"
-          },
-          {
-            "key": "payment_option_description_font_android",
-            "type": "android_font_selector",
-            "label_tooltip": "Font for the Payment Option Description for android.",
-            "initial_value": "Roboto-Regular"
-          },
-          {
-            "key": "payment_option_description_fontsize",
-            "type": "number_input",
-            "label_tooltip": "Font Size for Payment Option Description.",
-            "initial_value": "14"
-          },
-          {
-            "key": "payment_option_description_fontcolor",
-            "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for Payment Option Description.",
-            "initial_value": "rgba(66,74,87,1)"
-          },
-          {
-            "key": "payment_option_button_background",
-            "type": "color_picker_rgba",
-            "label": "Payment Option Action Button Background Color",
-            "label_tooltip": "Background Color for the Payment Option Action Button.",
+            "label_tooltip": "Default Background Color for the Payment Option Action.",
             "initial_value": "rgba(39, 218, 134, 1)"
           },
           {
-            "key": "payment_option_button_corner_radius",
+            "key": "payment_option_active_default_action_background_color",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Default Background Color for the Payment Option Action.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "payment_option_title_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the payment option title for Android TV.",
+            "initial_value": "Roboto-Dark"
+          },
+          {
+            "key": "payment_option_title_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the payment option title for TvOS.",
+            "initial_value": "HelveticaNeue-Bold"
+          },
+          {
+            "key": "payment_option_title_text_fontsize",
             "type": "number_input",
-            "label": "Payment Option Action Button Corner Radius",
-            "label_tooltip": "Corner Radius for the Payment Option Action Button.",
+            "label_tooltip": "Font size for the payment option title",
             "initial_value": "18"
           },
           {
-            "key": "payment_option_button_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for the Payment Option Action Button Text for ios.",
+            "key": "payment_option_title_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for the payment option title",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "payment_option_description_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the payment option description for Android TV.",
+            "initial_value": "Roboto-Dark"
+          },
+          {
+            "key": "payment_option_description_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the payment option description for TvOS.",
+            "initial_value": "HelveticaNeue-Bold"
+          },
+          {
+            "key": "payment_option_description_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font size for the payment option description",
+            "initial_value": "18"
+          },
+          {
+            "key": "payment_option_description_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for the payment option description",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "payment_option_fee_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the payment option fee for Android TV.",
+            "initial_value": "Roboto-Dark"
+          },
+          {
+            "key": "payment_option_fee_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the payment option fee for TvOS.",
+            "initial_value": "HelveticaNeue-Bold"
+          },
+          {
+            "key": "payment_option_fee_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font size for the payment option fee",
+            "initial_value": "36"
+          },
+          {
+            "key": "payment_option_fee_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for the payment option fee",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "payment_option_action_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the payment option action button for Android TV.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "payment_option_action_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the payment option action button for TvOS.",
+            "initial_value": "HelveticaNeue-Bold"
+          },
+          {
+            "key": "payment_option_action_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font size for the payment option action button",
+            "initial_value": "30"
+          },
+          {
+            "key": "payment_option_action_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for the payment option action button",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "restore_purchase_action_button_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Main Title for the restore purchases button for Android TV.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "restore_purchase_action_button_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the Main Title for the restore purchases button for TvOS.",
+            "initial_value": "HelveticaNeue"
+          },
+          {
+            "key": "restore_purchase_action_button_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size Main Title for the restore purchases button.",
+            "initial_value": "30"
+          },
+          {
+            "key": "restore_purchase_action_button_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color Main Title for the restore purchases button",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "restore_purchase_action_button_background_color",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Default Background Color for the Restore Purchases Button.",
+            "initial_value": "rgba(70, 79, 97, 1)"
+          },
+          {
+            "key": "restore_purchase_active_action_button_background_color",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Default Background Color for the Active Restore Purchases Button.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "subscriber_agreement_and_privacy_policy_text_font_android_tv",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for the Subscriber Agreement and Privacy Policy Link for Android TV.",
+            "initial_value": "Roboto-Medium"
+          },
+          {
+            "key": "subscriber_agreement_and_privacy_policy_text_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for the Subscriber Agreement and Privacy Policy Link for TvOS.",
+            "initial_value": "HelveticaNeue-Medium"
+          },
+          {
+            "key": "subscriber_agreement_and_privacy_policy_text_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size Subscriber Agreement and Privacy Policy Link.",
+            "initial_value": "24"
+          },
+          {
+            "key": "subscriber_agreement_and_privacy_policy_text_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color Subscriber Agreement and Privacy Policy Link",
+            "initial_value": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "key": "subscriber_agreement_and_privacy_policy_text_active_color",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Color for the Active Subscriber Agreement and Privacy Policy Link ",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          }
+        ]
+      },
+      {
+        "group": true,
+        "label": "Account Design and Text",
+        "tooltip": "These fields affect the design of the screen plugin.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "login_title_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Login Title Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "login_title_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Login Title Text for Android TV.",
             "initial_value": "Roboto-Bold"
           },
           {
-            "key": "payment_option_button_font_android",
+            "key": "login_title_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Login Title Text.",
+            "initial_value": "60"
+          },
+          {
+            "key": "login_title_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Login Title Text.",
+            "initial_value": "#545A5C"
+          },
+          {
+            "key": "main_description_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Main Description Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "main_description_font_android",
             "type": "android_font_selector",
-            "label_tooltip": "Font for the Payment Option Action Button Text for android.",
+            "label_tooltip": "Font for Main Description Text for Android TV.",
             "initial_value": "Roboto-Bold"
           },
           {
-            "key": "payment_option_button_fontsize",
+            "key": "main_description_fontsize",
             "type": "number_input",
-            "label_tooltip": "Font Size for Payment Option Action Button Text.",
-            "initial_value": "12"
+            "label_tooltip": "Font Size for Main Description Text.",
+            "initial_value": "38"
           },
           {
-            "key": "payment_option_button_fontcolor",
+            "key": "main_description_fontcolor",
             "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for Payment Option Action Button Text.",
-            "initial_value": "rgba(255, 255, 255, 1)"
+            "label_tooltip": "Font Color for Main Description Text.",
+            "initial_value": "#545A5C"
           },
           {
-            "key": "terms_of_use_instructions_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for the Terms of Use Instructions Text for ios.",
-            "initial_value": "Roboto-Regular"
+            "key": "optional_instructions_1_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Optional Instructions 1 Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
           },
           {
-            "key": "terms_of_use_instructions_font_android",
+            "key": "optional_instructions_1_font_android",
             "type": "android_font_selector",
-            "label_tooltip": "Font for the Terms of Use Instructions Text for android.",
-            "initial_value": "Roboto-Regular"
+            "label_tooltip": "Font for Optional Instructions 1 Text for Android TV.",
+            "initial_value": "Roboto-Bold"
           },
           {
-            "key": "terms_of_use_instructions_fontsize",
+            "key": "optional_instructions_1_fontsize",
             "type": "number_input",
-            "label_tooltip": "Font Size for the Terms of Use Instructions Text.",
-            "initial_value": "10"
+            "label_tooltip": "Font Size for Optional Instructions 1 Text.",
+            "initial_value": "26"
           },
           {
-            "key": "terms_of_use_instructions_fontcolor",
+            "key": "optional_instructions_1_fontcolor",
             "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for the Terms of Use Instructions Text.",
-            "initial_value": "rgba(255, 255, 255, 1)"
+            "label_tooltip": "Font Color for Optional Instructions 1 Text.",
+            "initial_value": "#545A5C"
           },
           {
-            "key": "terms_of_use_link",
-            "type": "text_input",
-            "label": "Payment Terms of use Link",
-            "label_tooltip": "Link for the Terms of Use.",
-            "initial_value": "http://google.com"
+            "key": "optional_instructions_2_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Optional Instructions 2 Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
           },
           {
-            "key": "terms_of_use_link_font_ios",
-            "type": "ios_font_selector",
-            "label_tooltip": "Font for the Terms of Use Link Text for ios.",
-            "initial_value": "Roboto-Regular"
-          },
-          {
-            "key": "terms_of_use_link_font_android",
+            "key": "optional_instructions_2_font_android",
             "type": "android_font_selector",
-            "label_tooltip": "Font for the Terms of Use Link Text for android.",
+            "label_tooltip": "Font for Optional Instructions 2 Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "optional_instructions_2_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Optional Instructions 2 Text.",
+            "initial_value": "26"
+          },
+          {
+            "key": "optional_instructions_2_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Optional Instructions 2 Text.",
+            "initial_value": "#545A5C"
+          },
+          {
+            "key": "use_dark_keyboard",
+            "type": "switch",
+            "label": "Use Dark Keyboard",
+            "label_tooltip": "Enables the dark keyboard appearance.",
+            "initial_value": "false"
+          },
+          {
+            "key": "email_input_background",
+            "type": "color_picker_rgba",
+            "label": "Email Input Background Color",
+            "label_tooltip": "Background Color for the Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "email_input_background_focused",
+            "type": "color_picker_rgba",
+            "label": "Email Input Background Color (focused)",
+            "label_tooltip": "Background Color for the Focused Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "email_input_background_filled",
+            "type": "color_picker_rgba",
+            "label": "Email Input Background Color (filled)",
+            "label_tooltip": "Background Color for the Filled Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "email_input_border_color",
+            "type": "color_picker_rgba",
+            "label": "Email Input Border Color",
+            "label_tooltip": "Border Color for the Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "email_input_border_color_focused",
+            "type": "color_picker_rgba",
+            "label": "Email Input Border Color (focused)",
+            "label_tooltip": "Border Color for the Focused Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "email_input_border_color_filled",
+            "type": "color_picker_rgba",
+            "label": "Email Input Border Color (filled)",
+            "label_tooltip": "Border Color for the Filled Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "email_input_placeholder_color",
+            "type": "color_picker_rgba",
+            "label": "Email Input Placeholder Color (filled)",
+            "label_tooltip": "Color for the Email Input Placeholder.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "email_input_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Email Input Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "email_input_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Email Input Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "email_input_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Email Input Field.",
+            "initial_value": "30"
+          },
+          {
+            "key": "email_input_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Email Input Field.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "password_input_background",
+            "type": "color_picker_rgba",
+            "label": "Password Input Background Color",
+            "label_tooltip": "Background Color for the Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "password_input_background_focused",
+            "type": "color_picker_rgba",
+            "label": "Password Input Background Color (focused)",
+            "label_tooltip": "Background Color for the Focused Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "password_input_background_filled",
+            "type": "color_picker_rgba",
+            "label": "Password Input Background Color (filled)",
+            "label_tooltip": "Background Color for the Filled Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "password_input_border_color",
+            "type": "color_picker_rgba",
+            "label": "Password Input Border Color",
+            "label_tooltip": "Border Color for the Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "password_input_border_color_focused",
+            "type": "color_picker_rgba",
+            "label": "Password Input Border Color (focused)",
+            "label_tooltip": "Border Color for the Focused Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "password_input_border_color_filled",
+            "type": "color_picker_rgba",
+            "label": "Password Input Border Color (filled)",
+            "label_tooltip": "Border Color for the Filled Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "password_input_placeholder_color",
+            "type": "color_picker_rgba",
+            "label": "Password Input Placeholder Color",
+            "label_tooltip": "Color for the Password Input Placeholder.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "password_input_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Password Input Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "password_input_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Password Input Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "password_input_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Password Input Field.",
+            "initial_value": "30"
+          },
+          {
+            "key": "password_input_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Password Input Field.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "login_action_button_background",
+            "type": "color_picker_rgba",
+            "label": "Login Action Button Background Color",
+            "label_tooltip": "Background Color for the Login Action Button.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "login_action_button_background_focused",
+            "type": "color_picker_rgba",
+            "label": "Login Action Button Focused Background Color",
+            "label_tooltip": "Background Color for the Login Action Button",
+            "initial_value": "rgba(93, 2, 13, 1)"
+          },
+          {
+            "key": "login_action_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Login Action Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "login_action_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Login Action Button Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "login_action_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Login Action Button Text.",
+            "initial_value": "40"
+          },
+          {
+            "key": "login_action_button_border_radius",
+            "type": "number_input",
+            "label": "Login Action Button Corner Radius",
+            "label_tooltip": "Corner radius for a login button.",
+            "initial_value": "5"
+          },
+          {
+            "key": "login_action_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Login Action Button Text.",
+            "initial_value": "#545A5C"
+          },
+          {
+            "key": "login_action_button_fontcolor_focused",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Focused Login Action Button Text.",
+            "initial_value": "#545A5C"
+          },
+          {
+            "key": "enable_skip_functionality",
+            "type": "switch",
+            "label": "Enable Skip Functionality",
+            "label_tooltip": "Enables the ability to skip the login by using the back button or activating the skip button in the UI.",
+            "initial_value": "true"
+          },
+          {
+            "key": "skip_action_button_background",
+            "type": "color_picker_rgba",
+            "label": "Skip Action Button Background Color",
+            "label_tooltip": "Background Color for the Skip Action Button.",
+            "initial_value": "rgba(39, 218, 134, 1)",
+            "conditional_fields": [
+              {
+                "condition_value": [true],
+                "key": "general/enable_skip_functionality"
+              }
+            ]
+          },
+          {
+            "key": "skip_action_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Skip Action Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold",
+            "conditional_fields": [
+              {
+                "condition_value": [true],
+                "key": "general/enable_skip_functionality"
+              }
+            ]
+          },
+          {
+            "key": "skip_action_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Skip Action Button Text for Android TV.",
+            "initial_value": "Roboto-Bold",
+            "conditional_fields": [
+              {
+                "condition_value": [true],
+                "key": "general/enable_skip_functionality"
+              }
+            ]
+          },
+          {
+            "key": "skip_action_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Skip Action Button Text.",
+            "initial_value": "40",
+            "conditional_fields": [
+              {
+                "condition_value": [true],
+                "key": "general/enable_skip_functionality"
+              }
+            ]
+          },
+          {
+            "key": "skip_action_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Skip Action Button Text.",
+            "initial_value": "#545A5C",
+            "conditional_fields": [
+              {
+                "condition_value": [true],
+                "key": "general/enable_skip_functionality"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "group": true,
+        "label": "Confirmation Screen Design and Text",
+        "tooltip": "These fields affect the design of plugin confirmation screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "confirmation_message_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Confirmation Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "confirmation_message_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Confirmation Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "confirmation_message_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for confirmation text.",
+            "initial_value": "41"
+          },
+          {
+            "key": "confirmation_message_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for confirmation text.",
+            "initial_value": "#FFFFFF"
+          },
+          {
+            "key": "confirm_action_button_background",
+            "type": "color_picker_rgba",
+            "label": "Confirm Action Button Background Color",
+            "label_tooltip": "Background Color for the Confirm Action Button.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "confirm_action_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Confirm Button for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "confirm_action_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Confirm Button for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "confirm_action_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Confirm Action Button Text.",
+            "initial_value": "40"
+          },
+          {
+            "key": "confirm_action_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Confirm Action Button Text.",
+            "initial_value": "#545A5C"
+          },
+          {
+            "key": "cancel_action_button_background",
+            "type": "color_picker_rgba",
+            "label": "Cancel Action Button Background Color",
+            "label_tooltip": "Background Color for the Cancel Action Button.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "cancel_action_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Cancel Button for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "cancel_action_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Cancel Button for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "cancel_action_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Cancel Action Button Text.",
+            "initial_value": "40"
+          },
+          {
+            "key": "cancel_action_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Cancel Action Button Text.",
+            "initial_value": "#545A5C"
+          }
+        ]
+      },
+      {
+        "group": true,
+        "label": "Alert Design and Text",
+        "tooltip": "These fields affect the design of plugin alert component.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "error_description_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Description Text for TvOS.",
+            "initial_value": "Helvetica"
+          },
+          {
+            "key": "error_description_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Description Text for Android TV.",
             "initial_value": "Roboto-Regular"
           },
           {
-            "key": "terms_of_use_link_fontsize",
+            "key": "error_description_fontsize",
             "type": "number_input",
-            "label_tooltip": "Font Size for the Terms of Use Link Text.",
-            "initial_value": "10"
+            "label_tooltip": "Font Size for Description Text.",
+            "initial_value": "36"
           },
           {
-            "key": "terms_of_use_link_fontcolor",
+            "key": "error_description_fontcolor",
             "type": "color_picker_rgba",
-            "label_tooltip": "Font Color for the Terms of Use Link Text.",
-            "initial_value": "rgba(255, 255, 255, 1)"
+            "label_tooltip": "Font Color for Description Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "close_action_button_background",
+            "type": "color_picker_rgba",
+            "label": "Alert “OK” Action Button Background Color",
+            "label_tooltip": "Background Color for the Alert “OK” Action Button. Will be used if no assets found.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "close_action_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for “OK” Action button Text for TvOS.",
+            "initial_value": "Helvetica"
+          },
+          {
+            "key": "close_action_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for “OK” Action button Text for Android TV.",
+            "initial_value": "Roboto-Regular"
+          },
+          {
+            "key": "close_action_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Alert “OK” Action Button Text.",
+            "initial_value": "41"
+          },
+          {
+            "key": "close_action_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Alert “OK” Action Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          }
+        ]
+      },
+      {
+        "group": true,
+        "label": "Signup screen designs",
+        "tooltip": "These fields affect the design of the signup screen",
+        "folded": true,
+        "fields": [
+          {
+            "key": "signup_title_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Signup Title Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "signup_title_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Signup Title Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "signup_title_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Signup Title Text.",
+            "initial_value": "60"
+          },
+          {
+            "key": "signup_title_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Signup Title Text.",
+            "initial_value": "rgba(33, 35, 36, 1)"
+          },
+          {
+            "key": "signup_action_button_background",
+            "type": "color_picker_rgba",
+            "label": "Sign Up Action Button Background Color",
+            "label_tooltip": "Background Color for the Sign Up Action Button.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_action_button_background_focused",
+            "type": "color_picker_rgba",
+            "label": "Sign Up Action Button Focused Background Color",
+            "label_tooltip": "Background Color for the Sign Up Action Button",
+            "initial_value": "rgba(93, 2, 13, 1)"
+          },
+          {
+            "key": "signup_action_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Sign Up Action Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "signup_action_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Sign Up Action Button Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "signup_action_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Sign Up Action Button Text.",
+            "initial_value": "40"
+          },
+          {
+            "key": "signup_action_button_border_radius",
+            "type": "number_input",
+            "label": "Sign Up Action Button Corner Radius",
+            "label_tooltip": "Corner radius for a Sign Up button.",
+            "initial_value": "5"
+          },
+          {
+            "key": "signup_action_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Sign Up Action Button Text.",
+            "initial_value": "#545A5C"
+          },
+          {
+            "key": "signup_action_button_fontcolor_focused",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Focused Sign Up Action Button Text.",
+            "initial_value": "#545A5C"
+          },
+          {
+            "key": "signup_password_input_background",
+            "type": "color_picker_rgba",
+            "label": "Password Input Background Color",
+            "label_tooltip": "Background Color for the Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_password_input_background_focused",
+            "type": "color_picker_rgba",
+            "label": "Password Input Background Color (focused)",
+            "label_tooltip": "Background Color for the Focused Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_password_input_background_filled",
+            "type": "color_picker_rgba",
+            "label": "Password Input Background Color (filled)",
+            "label_tooltip": "Background Color for the Filled Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_password_input_border_color",
+            "type": "color_picker_rgba",
+            "label": "Password Input Border Color",
+            "label_tooltip": "Border Color for the Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_password_input_border_color_focused",
+            "type": "color_picker_rgba",
+            "label": "Password Input Border Color (focused)",
+            "label_tooltip": "Border Color for the Focused Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_password_input_border_color_filled",
+            "type": "color_picker_rgba",
+            "label": "Password Input Border Color (filled)",
+            "label_tooltip": "Border Color for the Filled Password Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_password_input_placeholder_color",
+            "type": "color_picker_rgba",
+            "label": "Password Input Placeholder Color",
+            "label_tooltip": "Color for the Password Input Placeholder.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "signup_password_input_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Password Input Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "signup_password_input_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Password Input Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "signup_password_input_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Password Input Field.",
+            "initial_value": "30"
+          },
+          {
+            "key": "signup_password_input_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Password Input Field.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "signup_full_name_input_background",
+            "type": "color_picker_rgba",
+            "label": "Full Name Input Background Color",
+            "label_tooltip": "Background Color for the Full Name Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_full_name_input_background_focused",
+            "type": "color_picker_rgba",
+            "label": "Full Name Input Background Color (focused)",
+            "label_tooltip": "Background Color for the Focused Full Name Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_full_name_input_background_filled",
+            "type": "color_picker_rgba",
+            "label": "Full Name Input Background Color (filled)",
+            "label_tooltip": "Background Color for the Filled Full Name Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_full_name_input_border_color",
+            "type": "color_picker_rgba",
+            "label": "Full Name Input Border Color",
+            "label_tooltip": "Border Color for the Full Name Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_full_name_input_border_color_focused",
+            "type": "color_picker_rgba",
+            "label": "Full Name Input Border Color (focused)",
+            "label_tooltip": "Border Color for the Focused Full Name Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_full_name_input_border_color_filled",
+            "type": "color_picker_rgba",
+            "label": "Full Name Input Border Color (filled)",
+            "label_tooltip": "Border Color for the Filled Full Name Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_full_name_input_placeholder_color",
+            "type": "color_picker_rgba",
+            "label": "Full Name Input Placeholder Color",
+            "label_tooltip": "Color for the Full Name Input Placeholder.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "signup_full_name_input_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Full Name Input Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "signup_full_name_input_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Full Name Input Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "signup_full_name_input_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Full Name Input Field.",
+            "initial_value": "30"
+          },
+          {
+            "key": "signup_full_name_input_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Full Name Input Field.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "signup_email_input_background",
+            "type": "color_picker_rgba",
+            "label": "Email Input Background Color",
+            "label_tooltip": "Background Color for the Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_email_input_background_focused",
+            "type": "color_picker_rgba",
+            "label": "Email Input Background Color (focused)",
+            "label_tooltip": "Background Color for the Focused Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_email_input_background_filled",
+            "type": "color_picker_rgba",
+            "label": "Email Input Background Color (filled)",
+            "label_tooltip": "Background Color for the Filled Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_email_input_border_color",
+            "type": "color_picker_rgba",
+            "label": "Email Input Border Color",
+            "label_tooltip": "Border Color for the Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_email_input_border_color_focused",
+            "type": "color_picker_rgba",
+            "label": "Email Input Border Color (focused)",
+            "label_tooltip": "Border Color for the Focused Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_email_input_border_color_filled",
+            "type": "color_picker_rgba",
+            "label": "Email Input Border Color (filled)",
+            "label_tooltip": "Border Color for the Filled Email Input.",
+            "initial_value": "rgba(39, 218, 134, 1)"
+          },
+          {
+            "key": "signup_email_input_placeholder_color",
+            "type": "color_picker_rgba",
+            "label": "Email Input Placeholder Color",
+            "label_tooltip": "Color for the Email Input Placeholder.",
+            "initial_value": "#9B9B9B"
+          },
+          {
+            "key": "signup_email_input_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Email Input Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "signup_email_input_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Email Input Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "signup_email_input_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Email Input Field.",
+            "initial_value": "30"
+          },
+          {
+            "key": "signup_email_input_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Email Input Field.",
+            "initial_value": "#9B9B9B"
           }
         ]
       }
@@ -712,78 +1532,71 @@
         "initial_value": "Token should not be empty"
       },
       {
-        "key": "title_font_text",
-        "label": "Text title",
-        "initial_value": "InPlayer"
+        "key": "privacy_main_title_text",
+        "label": "Agreement and privacy screen title",
+        "initial_value": "Subscriber Agreement & Privacy Policy"
       },
       {
-        "key": "back_button_text",
-        "label": "Back button title",
-        "initial_value": "Back"
+        "key": "privacy_text",
+        "label": "Agreement and privacy text",
+        "initial_value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque sit amet nunc dui. Sed nec dignissim erat. Praesent molestie, odio et lacinia dapibus, lacus felis interdum justo, a viverra eros mauris vel nibh. Nullam consequat urna at lorem interdum, non mattis elit interdum. Cras libero erat, mattis ut mattis in, ornare ut ante. Duis id mi condimentum elit sagittis scelerisque. Duis facilisis vel lectus eu fermentum. Etiam venenatis fermentum felis nec ornare. Nullam pretium iaculis ligula sed accumsan.\n\n\nDonec id libero sit amet ligula cursus tempor. Donec urna felis, vestibulum id fringilla in, elementum ac diam. Nunc pretium, ligula ac accumsan accumsan, ipsum ante tristique nisi, et dictum dui arcu eu ex. Duis vel lectus quis nisl fringilla dictum. Praesent vulputate justo ligula, at commodo lorem sodales sed. Cras quis rhoncus ante. Nunc ultricies orci eget purus elementum, eget posuere elit semper. Suspendisse quis dignissim elit, eget dictum sem. Sed in nisl dui. Curabitur at sapien consectetur, lacinia turpis vitae, pharetra nisl. Nullam accumsan odio orci, quis elementum ex luctus id. Cras nec eros orci. Vestibulum eget convallis lectus. Donec eu lorem at purus elementum tempo."
       },
       {
-        "key": "fields_set_new_password_text",
-        "label": "New password field placeholder",
-        "initial_value": "New password"
-      },
-      {
-        "key": "fields_password_confirmation_text",
-        "label": "Password confirmation field placeholder",
-        "initial_value": "Password Confirmation"
-      },
-      {
-        "key": "fields_token_text",
-        "label": "Token field placeholder",
-        "initial_value": "Token"
-      },
-      {
-        "key": "forgot_password_text",
-        "label": "Forgot password text",
-        "initial_value": "Forgotten your Username or Password?"
-      },
-      {
-        "key": "create_account_link_text",
-        "label": "Create account text",
-        "initial_value": "No user? Sign Up!"
-      },
-      {
-        "key": "action_button_forgot_password_text",
-        "label": "Request password button title",
-        "initial_value": "REQUEST PASSWORD"
-      },
-      {
-        "key": "action_button_set_new_password_text",
-        "label": "Set new password button title",
-        "initial_value": "SET NEW PASSWORD"
-      },
-      {
-        "key": "payment_screen_title_text",
-        "label": "Payment screen title",
+        "key": "subscription_default_title_text",
+        "label": "Subscription default title",
         "initial_value": "Choose Your Subscription"
       },
       {
-        "key": "restore_purchases_text",
-        "label": "Restore purchases description",
-        "initial_value": "Purchased already a subscription?"
+        "key": "policy_agreement_text",
+        "label": "Policy agreement text",
+        "initial_value": "By clicking “Subscribe” or “Buy” below, you also agree to the [Client’s App Name] Agreement and acknowledge that you have read our Privacy Policy"
       },
       {
-        "key": "restore_purchases_link",
-        "label": "Restore purchases text",
+        "key": "subscriber_agreement_and_privacy_policy_text",
+        "label": "Subscriber Agreement and Privacy policy text",
+        "initial_value": "[Client’s Name App] Subscriber Agreement and Privacy Policy"
+      },
+      {
+        "key": "restore_purchase_action_button_text",
+        "label": "Restore purchases button title",
         "initial_value": "Restore"
       },
       {
-        "key": "terms_of_use_instructions_text",
-        "label": "Payment terms of use instruction",
-        "initial_value": "By making a selection and completing this transaction, you verify that you are at least 18 years old and agree to the"
+        "key": "payment_option_action_text_type_buy",
+        "label": "Buy button title",
+        "initial_value": "Buy"
       },
       {
-        "key": "terms_of_use_link_text",
-        "label": "Payment terms of use text",
-        "initial_value": "terms of use."
+        "key": "payment_option_action_text_type_subscribe",
+        "label": "Subscribe button title",
+        "initial_value": "Subscribe"
+      },
+      {
+        "key": "login_title_text",
+        "label": "Login title",
+        "initial_value": "Welcome To The App"
+      },
+      {
+        "key": "main_description_text",
+        "label": "Main description text",
+        "initial_value": "Helping companies maximize any cloud infrastructure, reduce costs, increase engagement, and significantly improve time to market and speed of ongoing innovation."
+      },
+      {
+        "key": "optional_instructions_1_text",
+        "label": "Optional instructions 1",
+        "initial_value": "Optional Instructions"
+      },
+      {
+        "key": "optional_instructions_2_text",
+        "label": "Optional instructions 2",
+        "initial_value": "Optional Instructions"
+      },
+      {
+        "key": "signup_title_text",
+        "label": "Signup title",
+        "initial_value": "Registration"
       }
     ]
   },
-  "targets": [
-    "mobile"
-  ]
+  "targets": ["tv"]
 }

--- a/plugins/login-plugin/manifests/manifest.config.js
+++ b/plugins/login-plugin/manifests/manifest.config.js
@@ -1904,7 +1904,7 @@ const androidPlatforms = [
   "amazon_fire_tv_for_quickbrick",
 ];
 
-const webPlatforms = ["samsung_tv"];
+const webPlatforms = ["samsung_tv", "lg_tv"];
 
 const applePlatforms = ["ios", "ios_for_quickbrick", "tvos_for_quickbrick"];
 
@@ -1913,6 +1913,7 @@ const tvPlatforms = [
   "android_tv_for_quickbrick",
   "amazon_fire_tv_for_quickbrick",
   "samsung_tv",
+  "lg_tv",
 ];
 
 const api = {
@@ -1985,7 +1986,7 @@ const min_zapp_sdk = {
   android_tv_for_quickbrick: "0.1.0-alpha1",
   amazon_fire_tv_for_quickbrick: "0.1.0-alpha1",
   samsung_tv: "1.2.2",
-  lg_tv: "1.0.0",
+  lg_tv: "1.2.0",
 };
 
 const isApple = R.includes(R.__, applePlatforms);

--- a/plugins/login-plugin/manifests/samsung_tv.json
+++ b/plugins/login-plugin/manifests/samsung_tv.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "3.1.1",
-  "manifest_version": "3.1.1",
+  "dependency_version": "3.1.4",
+  "manifest_version": "3.1.4",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/login-plugin/manifests/tvos_for_quickbrick.json
+++ b/plugins/login-plugin/manifests/tvos_for_quickbrick.json
@@ -111,8 +111,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "3.1.1",
-  "manifest_version": "3.1.1",
+  "dependency_version": "3.1.4",
+  "manifest_version": "3.1.4",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/login-plugin/package.json
+++ b/plugins/login-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer",
-  "version": "3.1.2",
+  "version": "3.1.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

This PR is an attempt to address the gaps with the LG manifest. LG was not added as a web platform, or a tv platform, so when all of the config values were updated for Samsung, Web, and TV platforms LG was getting left out. 

This means that the manifest for LG has been behind, and did not include critical features that were needed in the manifest.

I will need to do this PR on the frameworks repo as well.